### PR TITLE
BaSP-TG-35: Timesheet Unit Test - getAll, getById & delete

### DIFF
--- a/src/controllers/timeSheet.js
+++ b/src/controllers/timeSheet.js
@@ -71,7 +71,7 @@ const getAllTimesheets = async (req, res) => {
     }
     if (req.query.hours) {
       filterByParams = TimesheetFound.filter(
-        (timesheet) => timesheet.hours === req.query.hours,
+        (timesheet) => timesheet.hours === parseInt(req.query.hours, 10),
       );
     }
     return res.status(200).json({ filterByParams });

--- a/src/seeds/timesheets.js
+++ b/src/seeds/timesheets.js
@@ -19,7 +19,7 @@ export default [{
 }, {
   _id: mongoose.Types.ObjectId('6354438cfc13ae204b000066'),
   description: 'turpis nec euismod scelerisque',
-  date: '6/6/2022',
+  date: '06/06/2022',
   task: mongoose.Types.ObjectId('63546010fc13ae3a75000198'),
   employee: mongoose.Types.ObjectId('6354438cfc13ae204b000067'),
   project: mongoose.Types.ObjectId('6354438cfc13ae204b000068'),

--- a/src/tests/timesheets.test.js
+++ b/src/tests/timesheets.test.js
@@ -1,1 +1,38 @@
-test('Delete this test', () => {});
+import request from 'supertest';
+import timesheet from '../models/TimeSheet';
+import app from '../app';
+import timeSheetSeed from '../seeds/timesheets';
+
+beforeAll(async () => {
+  await timesheet.collection.insertMany(timeSheetSeed);
+});
+
+const timesheetId = '6354438cfc13ae204b000060';
+
+// const mockedTimesheet ={
+//     description: 'vitae nisl aenean',
+//     date: '1/1/2022',
+//     task: mongoose.Types.ObjectId('63546010fc13ae3a75000196'),
+//     employee: mongoose.Types.ObjectId('6354438cfc13ae204b000061'),
+//     project: mongoose.Types.ObjectId('6354438cfc13ae204b000062'),
+//     hours: 81
+// }
+
+describe('DELETE /timesheet/:id', () => {
+  test('should delete an employee', async () => {
+    const response = await request(app).delete(`/api/timesheets/${timesheetId}`).send();
+    expect(response.status).toBe(204);
+  });
+  test("if I don't pass the id the response should be a status 404", async () => {
+    const response = await request(app).delete('/api/timesheets/').send();
+    expect(response.status).toBe(404);
+  });
+  test('response status should be 404 with a wrong route ', async () => {
+    const response = await request(app).delete(`/api/timesheet/${timesheetId}`).send();
+    expect(response.status).toBe(404);
+  });
+  test('response status should be 404 with a wrong id', async () => {
+    const response = await request(app).delete('/api/timesheets/6356efc2fc13ae56b9000014').send();
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/tests/timesheets.test.js
+++ b/src/tests/timesheets.test.js
@@ -15,17 +15,6 @@ const timesheetEmployee = '6354438cfc13ae204b000064';
 const timesheetProject = '6354438cfc13ae204b000065';
 const timesheetHours = 98;
 
-// const invalidValue = null;
-
-// const mockedTimesheet ={
-//     description: 'vitae nisl aenean',
-//     date: '1/1/2022',
-//     task: mongoose.Types.ObjectId('63546010fc13ae3a75000196'),
-//     employee: mongoose.Types.ObjectId('6354438cfc13ae204b000061'),
-//     project: mongoose.Types.ObjectId('6354438cfc13ae204b000062'),
-//     hours: 81
-// }
-
 describe('DELETE /timesheet/:id', () => {
   test('should delete an employee', async () => {
     const response = await request(app).delete(`/api/timesheets/${timesheetId}`).send();
@@ -79,10 +68,17 @@ describe('GET /timesheet', () => {
     const response = await request(app).get(`/api/timesheets/?hours=${timesheetHours}`).send();
     expect(response.status).toBe(200);
   });
+});
+describe('GET /timesheet/:id', () => {
+  test('should find an employee by id', async () => {
+    const response = await request(app).get('/api/timesheets/6354438cfc13ae204b000069').send();
+    expect(response.status).toBe(200);
+    expect(response.body.data).toBeDefined();
+  });
 
-//   test('should find the timesheets filter by description', async () => {
-//       const response = await request(app).get(`/api/timesheets/?description=${invalidValue}`)
-//   .send();
-//       expect(response.status).toBe(404);
-//   });
+  test('should return status code 400', async () => {
+    const response = await request(app).get('/api/timesheets/6356efc2fc13ae56b9000014').send();
+    expect(response.status).toBe(404);
+    expect(response.body.data).toBeUndefined();
+  });
 });

--- a/src/tests/timesheets.test.js
+++ b/src/tests/timesheets.test.js
@@ -19,18 +19,22 @@ describe('DELETE /timesheet/:id', () => {
   test('should delete an employee', async () => {
     const response = await request(app).delete(`/api/timesheets/${timesheetId}`).send();
     expect(response.status).toBe(204);
+    expect(response.body.message).toBeUndefined();
   });
   test("if I don't pass the id the response should be a status 404", async () => {
     const response = await request(app).delete('/api/timesheets/').send();
     expect(response.status).toBe(404);
+    expect(response.body.message).toBeUndefined();
   });
   test('response status should be 404 with a wrong route ', async () => {
     const response = await request(app).delete(`/api/timesheet/${timesheetId}`).send();
     expect(response.status).toBe(404);
+    expect(response.body.message).toBeUndefined();
   });
   test('response status should be 404 with a wrong id', async () => {
     const response = await request(app).delete('/api/timesheets/6356efc2fc13ae56b9000014').send();
     expect(response.status).toBe(404);
+    expect(response.body.message).not.toBeUndefined();
   });
 });
 describe('GET /timesheet', () => {
@@ -73,12 +77,12 @@ describe('GET /timesheet/:id', () => {
   test('should find an employee by id', async () => {
     const response = await request(app).get('/api/timesheets/6354438cfc13ae204b000069').send();
     expect(response.status).toBe(200);
-    expect(response.body.data).toBeDefined();
   });
 
   test('should return status code 400', async () => {
     const response = await request(app).get('/api/timesheets/6356efc2fc13ae56b9000014').send();
     expect(response.status).toBe(404);
     expect(response.body.data).toBeUndefined();
+    expect(response.body.message).not.toBeUndefined();
   });
 });

--- a/src/tests/timesheets.test.js
+++ b/src/tests/timesheets.test.js
@@ -8,6 +8,14 @@ beforeAll(async () => {
 });
 
 const timesheetId = '6354438cfc13ae204b000060';
+const timesheetDesc = 'vitae nisl aenean';
+const timesheetDate = '1/1/2022';
+const timesheetTask = '63546010fc13ae3a75000196';
+const timesheetEmployee = '6354438cfc13ae204b000061';
+const timesheetProject = '6354438cfc13ae204b000062';
+const timesheetHours = 81;
+
+// const timesheetInvalidHours = 'asffgasd';
 
 // const mockedTimesheet ={
 //     description: 'vitae nisl aenean',
@@ -35,4 +43,54 @@ describe('DELETE /timesheet/:id', () => {
     const response = await request(app).delete('/api/timesheets/6356efc2fc13ae56b9000014').send();
     expect(response.status).toBe(404);
   });
+});
+describe('GET /timesheet', () => {
+  test('should find all the timesheets', async () => {
+    const response = await request(app).get('/api/timesheets').send();
+    expect(response.status).toBe(200);
+  });
+  test('should not find all the timesheets with a wrong route', async () => {
+    const response = await request(app).get('/api/timesheet').send();
+    expect(response.status).toBe(404);
+  });
+  test('should find the timesheets filter by description', async () => {
+    const response = await request(app).get(`/api/timesheets/?description=${timesheetDesc}`).send();
+    expect(response.status).toBe(200);
+  });
+  test('should find the timesheets filter by date', async () => {
+    const response = await request(app).get(`/api/timesheets/?date=${timesheetDate}`).send();
+    expect(response.status).toBe(200);
+  });
+  test('should find the timesheets filter by task', async () => {
+    const response = await request(app).get(`/api/timesheets/?task=${timesheetTask}`).send();
+    expect(response.status).toBe(200);
+  });
+  test('should find the timesheets filter by employee', async () => {
+    const response = await request(app).get(`/api/timesheets/?employee=${timesheetEmployee}`).send();
+    expect(response.status).toBe(200);
+  });
+  test('should find the timesheets filter by project', async () => {
+    const response = await request(app).get(`/api/timesheets/?project=${timesheetProject}`).send();
+    expect(response.status).toBe(200);
+  });
+  test('should find the timesheets filter by hours', async () => {
+    const response = await request(app).get(`/api/timesheets/?hours=${timesheetHours}`).send();
+    expect(response.status).toBe(200);
+  });
+
+  // test('should not find the timesheets with a invalid hours type', async () => {
+  //     const response = await request(app).get(`/api/timesheets/?hours=${timesheetInvalidHours}`)
+  // .send();
+  //     expect(response.status).toBe(404);
+  // });
+  // test('should find the timesheets filter by hours', async () => {
+  //     const response = await request(app).get(`/api/timesheets/?hours=10000`).send();
+  //     expect(response.status).toBe(404);
+  // });
+
+  // test('should find the timesheets filter by description', async () => {
+  //     const response = await request(app).get(`/api/timesheets/?description=esta desc no exite`)
+//   .send();
+  //     expect(response.status).toBe(404);
+  // });
 });

--- a/src/tests/timesheets.test.js
+++ b/src/tests/timesheets.test.js
@@ -7,15 +7,15 @@ beforeAll(async () => {
   await timesheet.collection.insertMany(timeSheetSeed);
 });
 
-const timesheetId = '6354438cfc13ae204b000060';
-const timesheetDesc = 'vitae nisl aenean';
-const timesheetDate = '1/1/2022';
-const timesheetTask = '63546010fc13ae3a75000196';
-const timesheetEmployee = '6354438cfc13ae204b000061';
-const timesheetProject = '6354438cfc13ae204b000062';
-const timesheetHours = 81;
+const timesheetId = '6354438cfc13ae204b000063';
+const timesheetDesc = 'orci mauris';
+const timesheetDate = '2/3/2022';
+const timesheetTask = '63546010fc13ae3a75000197';
+const timesheetEmployee = '6354438cfc13ae204b000064';
+const timesheetProject = '6354438cfc13ae204b000065';
+const timesheetHours = 98;
 
-// const timesheetInvalidHours = 'asffgasd';
+// const invalidValue = null;
 
 // const mockedTimesheet ={
 //     description: 'vitae nisl aenean',
@@ -53,6 +53,7 @@ describe('GET /timesheet', () => {
     const response = await request(app).get('/api/timesheet').send();
     expect(response.status).toBe(404);
   });
+
   test('should find the timesheets filter by description', async () => {
     const response = await request(app).get(`/api/timesheets/?description=${timesheetDesc}`).send();
     expect(response.status).toBe(200);
@@ -61,6 +62,7 @@ describe('GET /timesheet', () => {
     const response = await request(app).get(`/api/timesheets/?date=${timesheetDate}`).send();
     expect(response.status).toBe(200);
   });
+
   test('should find the timesheets filter by task', async () => {
     const response = await request(app).get(`/api/timesheets/?task=${timesheetTask}`).send();
     expect(response.status).toBe(200);
@@ -78,19 +80,9 @@ describe('GET /timesheet', () => {
     expect(response.status).toBe(200);
   });
 
-  // test('should not find the timesheets with a invalid hours type', async () => {
-  //     const response = await request(app).get(`/api/timesheets/?hours=${timesheetInvalidHours}`)
-  // .send();
-  //     expect(response.status).toBe(404);
-  // });
-  // test('should find the timesheets filter by hours', async () => {
-  //     const response = await request(app).get(`/api/timesheets/?hours=10000`).send();
-  //     expect(response.status).toBe(404);
-  // });
-
-  // test('should find the timesheets filter by description', async () => {
-  //     const response = await request(app).get(`/api/timesheets/?description=esta desc no exite`)
+//   test('should find the timesheets filter by description', async () => {
+//       const response = await request(app).get(`/api/timesheets/?description=${invalidValue}`)
 //   .send();
-  //     expect(response.status).toBe(404);
-  // });
+//       expect(response.status).toBe(404);
+//   });
 });


### PR DESCRIPTION
[delete] : tested when the id, route are wrong or when you forgot pass the id and when the id is valid
[getAll]: tested when you try to get all the list, filter by each field and when the route is wrong
[getById]: tested when you try to get a valid and/or invalid ID.