### PR TITLE
BaSP-TG-26: Task unit test getAll and getById

### DIFF
--- a/src/controllers/task.js
+++ b/src/controllers/task.js
@@ -26,17 +26,18 @@ const getOneTask = async (req, res) => {
     const { id } = req.params;
     const task = await Models.findById(id);
     if (!task) {
-      return res.status(404).json({
-        msg: 'The task has not been found',
-      });
+      // eslint-disable-next-line no-throw-literal
+      throw {
+        message: 'The task has not been found', status: 404,
+      };
     }
     return res.status(200).json({
       msg: 'The task has been found',
       data: task,
     });
-  } catch (err) {
-    return res.json({
-      message: `an error ocurred: ${err}`,
+  } catch (error) {
+    return res.status(error.status || 500).json({
+      message: error.message || error,
     });
   }
 };

--- a/src/tests/task.test.js
+++ b/src/tests/task.test.js
@@ -1,1 +1,42 @@
-test('Delete this test', () => {});
+import request from 'supertest';
+import app from '../app';
+import Task from '../models/Task';
+import taskSeed from '../seeds/task';
+
+beforeAll(async () => {
+  await Task.collection.insertMany(taskSeed);
+});
+
+const TaskWithId = {
+  _id: '63544114fc13ae2db7000330',
+  description: 'FE',
+};
+
+describe('getAll /tasks', () => {
+  test('should get all tasks', async () => {
+    const response = await request(app)
+      .get('/api/tasks/')
+      .send();
+    expect(response.status).toBe(200);
+    expect(response.body.error).toBeFalsy();
+    expect(response.body.data).toBeDefined();
+    expect(response.body.message).toBe('Tasks found');
+  });
+  test('should filter tasks by description', async () => {
+    const response = await request(app)
+      .get(`/api/tasks/?description=${TaskWithId.description}`)
+      .send();
+    expect(response.status).toBe(200);
+    expect(response.body.error).toBeFalsy();
+    expect(response.body.data)
+      .toEqual(expect.arrayContaining([expect.objectContaining(TaskWithId)]));
+  });
+
+  test('should get error 404 if the route is incorrect', async () => {
+    const response = await request(app)
+      .get('/api/task/')
+      .send();
+    expect(response.status).toBe(404);
+    expect(response.status.error).toBeUndefined();
+  });
+});

--- a/src/tests/task.test.js
+++ b/src/tests/task.test.js
@@ -7,6 +7,7 @@ beforeAll(async () => {
   await Task.collection.insertMany(taskSeed);
 });
 
+const taskInvalidId = '6354389ffc13ae2db7004444';
 const TaskWithId = {
   _id: '63544114fc13ae2db7000330',
   description: 'FE',
@@ -38,5 +39,24 @@ describe('getAll /tasks', () => {
       .send();
     expect(response.status).toBe(404);
     expect(response.status.error).toBeUndefined();
+  });
+});
+
+describe('getById /tasks', () => {
+  test('should get a task by ID', async () => {
+    const response = await request(app)
+    // eslint-disable-next-line no-underscore-dangle
+      .get(`/api/tasks/${TaskWithId._id}`)
+      .send();
+    expect(response.status).toBe(200);
+    expect(response.body.error).toBeFalsy();
+    expect(response.body.data).toEqual(TaskWithId);
+  });
+  test('should not find a task with the ID given thus return error 404', async () => {
+    const response = await request(app)
+      .get(`/api/tasks/${taskInvalidId}`)
+      .send();
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBeUndefined();
   });
 });


### PR DESCRIPTION
Task tests:

1. getAll:

- getAll tasks.
- filter tasks by description.
- throw error if the route is incorrect.

2. getById:

- get a task by ID.
- should not find a task with an invalid ID so it returns an error 404.