### PR TITLE
BASP-TG-51: Timesheet fix filterByDescription

### DIFF
--- a/src/controllers/timeSheet.js
+++ b/src/controllers/timeSheet.js
@@ -63,47 +63,9 @@ const getAllTimesheets = async (req, res) => {
         status: 404,
       };
     }
-    if (timesheetFound.length !== 0 && !req.query) {
-      return res.status(200).json({
-        message: 'Timesheet found',
-        data: timesheetFound,
-        error: false,
-      });
-    }
-    let filterByParams = [...timesheetFound];
-    if (req.query.description) {
-      filterByParams = timesheetFound.filter(
-        (timesheet) => timesheet.description === req.query.description,
-      );
-    }
-    if (req.query.date) {
-      filterByParams = filterByParams.filter(
-        (timesheet) => timesheet.date === req.query.date,
-      );
-    }
-    if (req.query.task) {
-      filterByParams = filterByParams.filter(
-        (timesheet) => timesheet.task === req.query.task,
-      );
-    }
-    if (req.query.employees) {
-      filterByParams = filterByParams.filter(
-        (timesheet) => timesheet.employee === req.query.employees,
-      );
-    }
-    if (req.query.project) {
-      filterByParams = filterByParams.filter(
-        (timesheet) => timesheet.project === req.query.project,
-      );
-    }
-    if (req.query.hours) {
-      filterByParams = filterByParams.filter(
-        (timesheet) => timesheet.hours === parseInt(req.query.hours, 10),
-      );
-    }
     return res.status(200).json({
       message: 'Timesheet found',
-      data: filterByParams,
+      data: timesheetFound,
       error: false,
     });
   } catch (error) {

--- a/src/controllers/timeSheet.js
+++ b/src/controllers/timeSheet.js
@@ -49,14 +49,11 @@ const createTimesheet = async (req, res) => {
 
 const getAllTimesheets = async (req, res) => {
   try {
-    const { id } = req.params;
-    const timesheetFound = req.query.disablePopulate
-      ? await Timesheet.find(id)
-      : await Timesheet.find(id)
-        .populate('task')
-        .populate('employee')
-        .populate('project');
-    if (!timesheetFound) {
+    const timesheetFound = await Timesheet.find(req.query)
+      .populate('task')
+      .populate('employee')
+      .populate('project');
+    if (!timesheetFound || !timesheetFound.length) {
       // eslint-disable-next-line no-throw-literal
       throw {
         message: 'Timesheet not found',

--- a/src/controllers/timeSheet.js
+++ b/src/controllers/timeSheet.js
@@ -63,7 +63,7 @@ const getAllTimesheets = async (req, res) => {
         status: 404,
       };
     }
-    if (timesheetFound.length !== 0) {
+    if (timesheetFound.length !== 0 && !req.query) {
       return res.status(200).json({
         message: 'Timesheet found',
         data: timesheetFound,
@@ -98,10 +98,14 @@ const getAllTimesheets = async (req, res) => {
     }
     if (req.query.hours) {
       filterByParams = filterByParams.filter(
-        (timesheet) => timesheet.hours === parseInt(req.query.hours, 10)
+        (timesheet) => timesheet.hours === parseInt(req.query.hours, 10),
       );
     }
-    return res.status(200).json({ filterByParams });
+    return res.status(200).json({
+      message: 'Timesheet found',
+      data: filterByParams,
+      error: false,
+    });
   } catch (error) {
     if (error instanceof Joi.ValidationError) error.status = 400;
     return res.status(error.status || 500).json({

--- a/src/tests/timesheets.test.js
+++ b/src/tests/timesheets.test.js
@@ -460,10 +460,10 @@ describe('[PUT] /api/timesheets/:id endpoint => UPDATE/EDIT a timesheet.', () =>
 const timesheetId = '6354438cfc13ae204b000063';
 const timesheetDesc = 'orci mauris';
 const timesheetDate = '2/3/2022';
-const timesheetTask = '63546010fc13ae3a75000197';
-const timesheetEmployee = '6354438cfc13ae204b000064';
-const timesheetProject = '6354438cfc13ae204b000065';
-const timesheetHours = 98;
+const timesheetTask = '63544114fc13ae2db7000337';
+const timesheetEmployee = '6354389ffc13ae2db700032f';
+const timesheetProject = '635446a1fc13ae04ac000214';
+const timesheetHours = 2;
 
 describe('DELETE /timesheet/:id', () => {
   test('should delete an employee', async () => {


### PR DESCRIPTION
Fix filterByDescription endpoint to get the request timesheet filtered by description! Also, this PR fix the bug in ticket n° 52, filtering by task ID should return the timesheet, and with invalid ID should return error message.